### PR TITLE
fix incorrect exception handling while parsing tap and sleeper

### DIFF
--- a/starsearch.js
+++ b/starsearch.js
@@ -1680,7 +1680,7 @@ function parse_xml(contents) { // {{{
 			const coord = get_coord(system_node).textContent.split('|');
 			const tags_element = get_named_child(system_node, 'tags');
 			const tags = [];
-			if(!(typeof children === 'undefined')){
+			if(!(typeof tags_element.children === 'undefined')){
 				for (const st of tags_element.children) {
 					tags.push(st.textContent);
 				}


### PR DESCRIPTION
Simple fix for parsing coronal tap and cryosleeper. Error handling check was calling "children" on nothing.