### PR TITLE
Fix missing loc for some `d` entries

### DIFF
--- a/starsearch.js
+++ b/starsearch.js
@@ -1703,9 +1703,13 @@ function parse_xml(contents) { // {{{
 		}
     });
     body_coords = {};
-    xml.querySelectorAll('d[cl="Plnt"]').forEach(function (d_node) {
-        const body_id = d_node.getAttribute('ref');
-        const loc_node = get_named_child(d_node.parentElement.parentElement.parentElement, 'loc');
+    xml.querySelectorAll('iSE[cl="Plnt"]').forEach(function (iseNode) {
+        const body_id = iseNode.getAttribute('ref');
+        const jump_point = iseNode.parentElement.parentElement;
+        if (jump_point.tagName == 'NGW') {
+            return;
+        }
+        const loc_node = get_named_child(jump_point, 'loc');
         const coords = loc_node.textContent.split('|');
         body_coords[body_id] = { 'x': Number(coords[0]), 'y': Number(coords[1]) };
     });


### PR DESCRIPTION
I'm playing v0.97a and I was getting an error because some of the `d` nodes are in a different part of the tree than others. These `d` nodes had a unique reference (and they were planets) but it wasn't easy to find the `loc` from the tree. It seems more consistent to look at `iSE` nodes and discard some repeats.

Honestly the only thing I've tested is that it comes up with suggestions and doesn't throw parser errors -- some stuff may still be missing when parsing.
I also don't know whether this will work with prior versions.
But even if it's not 100% it's cool to see it sort-of work for my savefile 😄 thanks for your efforts.